### PR TITLE
Fix failing build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenCentral()
         maven {
@@ -37,6 +38,7 @@ android {
 
 allprojects {
     repositories {
+        google()
         mavenCentral()
         jcenter()
         maven {


### PR DESCRIPTION
According to this issue we only need to add the `google()` repo as the first repo.
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360001331200-Android-build-miss-intellij-core-26-0-1-jar

I tried it and it works fine now.