### PR TITLE
chore: remove usage of jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
             mavenCentral()
         }
 
@@ -40,7 +39,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
# Info

I got a warning message about shutting down jcenter.

    WARNING:: Please remove usages of jcenter() Maven repository from your build scripts and migrate your build to other Maven repositories.
    This repository is deprecated and it will be shut down in the future.
    See http://developer.android.com/r/tools/jcenter-end-of-service for more information.

Using this information we can drop this repo from gradle file.