### PR TITLE
fix: move podspec to package root

### DIFF
--- a/SRSRadialGradient.podspec
+++ b/SRSRadialGradient.podspec
@@ -1,5 +1,5 @@
 require 'json'
-version = JSON.parse(File.read('../package.json'))["version"]
+version = JSON.parse(File.read('./package.json'))["version"]
 
 Pod::Spec.new do |s|
 
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
   s.source          = { :git => "https://github.com/surajitsarkar19/react-native-radial-gradient.git", :tag => "v#{s.version}" }
-  s.source_files    = 'SRSRadialGradient/*.{h,m}'
+  s.source_files    = 'ios/**/*.{h,m}'
   s.preserve_paths  = "**/*.js"
   s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'
 


### PR DESCRIPTION
## Summary

fixes #45 
Ios podspec needs to be at the root of the package as mentioned [here](https://github.com/react-native-community/cli/blob/55bda446ec338e864be8f0af9e47da91a511392d/docs/autolinking.md?plain=1#L37)